### PR TITLE
fix: シリアルWAV転送の速度を手動指定可能に変更

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -222,6 +222,16 @@ uv run tools/stackchan_atama.py --wifi capture -o /tmp/photo.jpg
 - **VOICEVOX接続エラー**: `docker ps` でコンテナ起動確認、または `curl http://localhost:50021/version` で疎通確認
 - **音が鳴らない**: `uv run tools/stackchan_atama.py volume 255` で最大音量に設定
 - **シリアルポートが掴まれている**: `lsof /dev/ttyACM0` で確認、`fuser -k /dev/ttyACM0` で解放
+- **シリアルでWAV転送が失敗する（`no READY response` / `no confirmation received`）**:
+  ホストPCの性能やUSBコントローラの特性により、デフォルトの転送速度（1KB/5ms）が速すぎる場合がある。
+  まずデフォルトで `say` を試し、失敗したら `--serial-chunk` と `--serial-delay` で速度を落とす：
+  ```bash
+  # デフォルト（高速ホスト向け）
+  uv run tools/stackchan_atama.py say "テスト"
+
+  # 転送が失敗する場合（Raspberry Pi等の低速ホスト向け）
+  uv run tools/stackchan_atama.py --serial-chunk 256 --serial-delay 0.02 say "テスト"
+  ```
 
 ## 使用例
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -258,6 +258,7 @@ void handleStatus(AsyncWebServerRequest *request) {
   doc["ip"] = WiFi.localIP().toString();
   doc["playing"] = wav_playing;
   doc["queued"] = wavQueueCount();
+  doc["psram"] = psramFound();
 
   String json;
   serializeJson(doc, json);
@@ -374,18 +375,20 @@ void handleSerialCommand(const String& cmd) {
 
   } else if (cmd == "STATUS") {
 #if defined(ENABLE_CAMERA)
-    Serial.printf("{\"status\":\"online\",\"wifi\":%s,\"ip\":\"%s\",\"playing\":%s,\"queued\":%d,\"camera\":%s}\n",
+    Serial.printf("{\"status\":\"online\",\"wifi\":%s,\"ip\":\"%s\",\"playing\":%s,\"queued\":%d,\"camera\":%s,\"psram\":%s}\n",
       wifi_connected ? "true" : "false",
       wifi_connected ? WiFi.localIP().toString().c_str() : "none",
       wav_playing ? "true" : "false",
       wavQueueCount(),
-      camera_initialized ? "true" : "false");
+      camera_initialized ? "true" : "false",
+      psramFound() ? "true" : "false");
 #else
-    Serial.printf("{\"status\":\"online\",\"wifi\":%s,\"ip\":\"%s\",\"playing\":%s,\"queued\":%d,\"camera\":false}\n",
+    Serial.printf("{\"status\":\"online\",\"wifi\":%s,\"ip\":\"%s\",\"playing\":%s,\"queued\":%d,\"camera\":false,\"psram\":%s}\n",
       wifi_connected ? "true" : "false",
       wifi_connected ? WiFi.localIP().toString().c_str() : "none",
       wav_playing ? "true" : "false",
-      wavQueueCount());
+      wavQueueCount(),
+      psramFound() ? "true" : "false");
 #endif
 
   } else if (cmd == "WIFI:CLEAR") {

--- a/tools/stackchan_atama.py
+++ b/tools/stackchan_atama.py
@@ -117,7 +117,7 @@ class StackchanSerial:
         except json.JSONDecodeError:
             return {"raw": response}
 
-    def send_wav(self, wav_data):
+    def send_wav(self, wav_data, chunk_size=1024, chunk_delay=0.005):
         """Send WAV binary data with flow control"""
         self.ser.write(f"WAV:{len(wav_data)}\n".encode())
         self.ser.flush()
@@ -135,14 +135,13 @@ class StackchanSerial:
         if not ready:
             return {"status": "error", "error": "no READY response"}
 
-        # Send in 256B chunks with 20ms delay (Core without PSRAM needs slower transfer)
-        CHUNK = 256
+        # Send in chunks
         sent = 0
         while sent < len(wav_data):
-            end = min(sent + CHUNK, len(wav_data))
+            end = min(sent + chunk_size, len(wav_data))
             self.ser.write(wav_data[sent:end])
             sent = end
-            time.sleep(0.02)
+            time.sleep(chunk_delay)
         self.ser.flush()
 
         # Wait for OK response
@@ -402,14 +401,14 @@ def cmd_say(args):
                 break
             i, chunk, wav, tts_time = item
             t0 = time.time()
-            result = sc.send_wav(wav)
+            result = sc.send_wav(wav, chunk_size=args.serial_chunk, chunk_delay=args.serial_delay)
             send_time = time.time() - t0
             print(f"  [{i+1}/{len(chunks)}] TTS:{tts_time:.2f}s Send:{send_time:.2f}s ({len(wav)}B) {chunk}", file=sys.stderr)
 
         executor.shutdown(wait=False)
     else:
         wav = synthesize(args.text, args)
-        result = sc.send_wav(wav)
+        result = sc.send_wav(wav, chunk_size=args.serial_chunk, chunk_delay=args.serial_delay)
         result["text"] = args.text
         result["wav_size"] = len(wav)
         result["tts"] = args.tts
@@ -506,6 +505,10 @@ def main():
                         help="Path to piper .onnx model file (env: PIPER_MODEL)")
     parser.add_argument("--piper-speaker", type=int, default=0,
                         help="Piper speaker ID for multi-speaker models (default: 0)")
+    parser.add_argument("--serial-chunk", type=int, default=1024,
+                        help="Serial transfer chunk size in bytes (default: 1024, try 256 if transfer fails)")
+    parser.add_argument("--serial-delay", type=float, default=0.005,
+                        help="Delay between serial chunks in seconds (default: 0.005, try 0.02 if transfer fails)")
     sub = parser.add_subparsers(dest="command", required=True)
 
     p_say = sub.add_parser("say", help="Speak text via TTS (VOICEVOX or piper)")

--- a/tools/stackchan_atama.py
+++ b/tools/stackchan_atama.py
@@ -401,14 +401,20 @@ def cmd_say(args):
                 break
             i, chunk, wav, tts_time = item
             t0 = time.time()
-            result = sc.send_wav(wav, chunk_size=args.serial_chunk, chunk_delay=args.serial_delay)
+            if isinstance(sc, StackchanSerial):
+                result = sc.send_wav(wav, chunk_size=args.serial_chunk, chunk_delay=args.serial_delay)
+            else:
+                result = sc.send_wav(wav)
             send_time = time.time() - t0
             print(f"  [{i+1}/{len(chunks)}] TTS:{tts_time:.2f}s Send:{send_time:.2f}s ({len(wav)}B) {chunk}", file=sys.stderr)
 
         executor.shutdown(wait=False)
     else:
         wav = synthesize(args.text, args)
-        result = sc.send_wav(wav, chunk_size=args.serial_chunk, chunk_delay=args.serial_delay)
+        if isinstance(sc, StackchanSerial):
+            result = sc.send_wav(wav, chunk_size=args.serial_chunk, chunk_delay=args.serial_delay)
+        else:
+            result = sc.send_wav(wav)
         result["text"] = args.text
         result["wav_size"] = len(wav)
         result["tts"] = args.tts

--- a/tools/stackchan_atama.py
+++ b/tools/stackchan_atama.py
@@ -135,14 +135,14 @@ class StackchanSerial:
         if not ready:
             return {"status": "error", "error": "no READY response"}
 
-        # Send in 1KB chunks with 5ms delay
-        CHUNK = 1024
+        # Send in 256B chunks with 20ms delay (Core without PSRAM needs slower transfer)
+        CHUNK = 256
         sent = 0
         while sent < len(wav_data):
             end = min(sent + CHUNK, len(wav_data))
             self.ser.write(wav_data[sent:end])
             sent = end
-            time.sleep(0.005)
+            time.sleep(0.02)
         self.ser.flush()
 
         # Wait for OK response


### PR DESCRIPTION
## Summary
- シリアルWAV転送の速度を固定値から `--serial-chunk` / `--serial-delay` オプションで指定可能に変更
- 自動判定はせず、デフォルト高速（1024B/5ms）で動作。低速ホスト（Raspberry Pi等）では `--serial-chunk 256 --serial-delay 0.02` に変更
- STATUSレスポンスに `psram` フィールドを追加
- SKILL.md のトラブルシューティングに転送速度調整の手順を追記
- WiFiモードで `send_wav` にシリアル専用引数が渡るバグを修正

## Test plan
- [x] デフォルト設定（1024B/5ms）で高速ホストでの転送確認
- [x] `--serial-chunk 256 --serial-delay 0.02` でRaspberry Piでの転送確認
- [x] パイプラインモードでの長文再生確認
- [x] WiFi経由でのsayコマンド動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)