### PR TITLE
SKILL.md整理 + piper-plusデフォルト化 + IP環境変数化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 .vscode/launch.json
 .vscode/ipch
 compile_commands.json
+
+# piper-plus (symlinks to local install, set up per environment)
+tools/piper
+models/

--- a/README.md
+++ b/README.md
@@ -9,8 +9,19 @@
 - **USB シリアルで PC から制御**（WiFi 不要）
 - PC から WAV データを送信 → スピーカー再生 + 口パク
 - 表情変更（happy, sad, angry, sleepy, doubt, neutral）
-- TTS は PC 側で自由に選択（ローカル VOICEVOX 等）
+- TTS は PC 側で自由に選択（piper-plus / VOICEVOX 等）
 - パイプライン再生対応（文を分割して順次送信、最初のチャンクを即座に再生開始）
+
+### 通常のスタックチャンとの違い
+
+- **stackchan（既存）**: WiFi HTTP API、AI_StackChan2ファームウェア、サーボ付き
+- **stackchan-atama（本プロジェクト）**: USBシリアル or WiFi、専用ファームウェア、アタマだけ（サーボなし）
+
+### スキル構成
+
+- `tools/stackchan_atama.py` - 制御CLI（pyserial + requests）
+- `src/main.cpp` - M5Stack用ファームウェア（PlatformIO）
+- `platformio.ini` - ビルド設定（CoreS3 / Core / Core2）
 
 ## 動作確認済みデバイス
 
@@ -63,7 +74,9 @@ WiFi 接続時は HTTP API も使用可能：
 - M5Stack Core / Core2 / CoreS3 のいずれか
 - USB-C ケーブル
 - [PlatformIO CLI](https://docs.platformio.org/en/stable/core/installation.html)（`uv tool install platformio` でもOK）
-- [VOICEVOX Engine](https://voicevox.hiroshiba.jp/)（音声合成用、PC 側で起動）
+- TTS エンジン（以下のいずれか）:
+  - [piper-plus](https://github.com/ayutaz/piper-plus)（デフォルト。サーバー不要、ARM64対応）
+  - [VOICEVOX Engine](https://voicevox.hiroshiba.jp/)（`--tts voicevox` で切替）
 
 ### ビルド & 書き込み
 
@@ -142,17 +155,49 @@ uv run stackchan_atama.py capture -o photo.jpg
 uv run stackchan_atama.py --port /dev/ttyACM1 status
 ```
 
-### VOICEVOX Engine の起動
+### TTS エンジンの設定
 
-PC 側で VOICEVOX Engine が動いている必要があります：
+デフォルトは piper-plus。環境変数 `STACKCHAN_TTS` で切替可能。
+
+#### piper-plus（デフォルト）
+
+サーバー不要、バイナリ単体で動作。ARM64（Raspberry Pi / DGX Spark）対応。
+
+スクリプトは `tools/piper`（バイナリ）と `models/*.onnx`（モデル）を自動検出します。
+シンボリックリンクまたはコピーで配置してください：
 
 ```bash
-# Docker
+# piper-plus バイナリ
+ln -s /path/to/piper-plus/piper/bin/piper tools/piper
+
+# モデルファイル + config
+mkdir -p models
+ln -s /path/to/piper-plus/models/tsukuyomi-chan-6lang-fp16.onnx models/
+ln -s /path/to/piper-plus/models/config.json models/
+```
+
+環境変数 `PIPER_BIN` / `PIPER_MODEL` での指定も可能（自動検出より優先）。
+
+#### VOICEVOX（オプション）
+
+```bash
+export STACKCHAN_TTS=voicevox
+
+# Docker で起動
 docker run --rm -p 50021:50021 voicevox/voicevox_engine:cpu-latest
 
-# または直接インストール
-# https://voicevox.hiroshiba.jp/ からダウンロード
+# 確認
+curl http://localhost:50021/version
 ```
+
+### 環境変数一覧
+
+| 変数 | デフォルト | 説明 |
+|------|----------|------|
+| `STACKCHAN_TTS` | `piper` | TTS エンジン（`piper` or `voicevox`） |
+| `STACKCHAN_IP` | `192.168.1.100` | WiFi モード時の IP アドレス |
+| `PIPER_BIN` | `piper` | piper バイナリのパス |
+| `PIPER_MODEL` | （なし） | piper モデルファイル（.onnx）のパス |
 
 ### WiFi 設定（オプション）
 
@@ -184,6 +229,15 @@ curl -o photo.jpg http://<CoreS3のIP>/capture
 ```
 
 解像度は QVGA (320x240)。Vision API に送る用途に十分な画質です。
+
+## トラブルシューティング
+
+- **Permission denied（Linux）**: `sudo usermod -aG dialout $USER` して再ログイン
+- **ポートが見つからない**: USBケーブルがデータ転送対応か確認（充電専用ケーブルはNG）
+- **VOICEVOX接続エラー**: `docker ps` でコンテナ起動確認、または `curl http://localhost:50021/version` で疎通確認
+- **音が鳴らない**: `uv run stackchan_atama.py volume 255` で最大音量に設定
+- **シリアルポートが掴まれている**: `lsof /dev/ttyACM0` で確認、`fuser -k /dev/ttyACM0` で解放
+- **シリアルでWAV転送が失敗する**: `--serial-chunk 256 --serial-delay 0.02` で転送速度を落とす
 
 ## AI エージェント連携
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,85 +5,23 @@ description: スタックチャン・アタマ（M5Stack単体版）をUSBシリ
 
 # スタックチャン・アタマ制御スキル
 
-USBシリアルまたはWiFi HTTP API経由でスタックチャン・アタマ（M5Stack単体、サーボ不要版）を制御する。テキスト読み上げ、表情変更、音量調整、カメラ撮影、WAVファイル再生が可能。
-
-## 通常のスタックチャンとの違い
-
-- **stackchan（既存）**: WiFi HTTP API、AI_StackChan2ファームウェア、サーボ付き
-- **stackchan-atama（本スキル）**: USBシリアル or WiFi、専用ファームウェア、アタマだけ（サーボなし）
-
-## スキル構成
-
-- `tools/stackchan_atama.py` - 制御CLI（pyserial + requests）
-- `src/main.cpp` - M5Stack用ファームウェア（PlatformIO）
-- `platformio.ini` - ビルド設定（CoreS3 / Core / Core2）
-
-## ファームウェア書き込み
-
-ファームウェアの更新が必要な場合（初回セットアップ、コード変更後など）。
-
-### 前提条件
-
-- PlatformIO CLI（`pio`）がインストール済み（なければ `uv tool install platformio`）
-- USBケーブルでデバイスを接続
-
-### 書き込みコマンド
-
-```bash
-cd [SKILL_DIR]
-
-# CoreS3の場合（推奨）
-pio run -e m5stack-cores3 -t upload
-
-# Core2の場合
-pio run -e m5stack-core2 -t upload
-
-# Core（初代）の場合
-pio run -e m5stack-core -t upload
-```
-
-- 画面にアバターの顔が出れば成功
-- 初回はライブラリダウンロードで時間がかかる（2回目以降は高速）
-- 書き込み後、自動的にデバイスがリセットされる
+USBシリアルまたはWiFi HTTP API経由でスタックチャン・アタマ（M5Stack単体、サーボ不要版）を制御する。
 
 ## 接続モード
 
 ### USBシリアル（デフォルト）
 
-- ポート: 自動検出（macOS: `/dev/cu.usbmodem*`, Linux: `/dev/ttyACM*`）。`--port` で手動指定も可能
-- ボーレート: 921600
-- プロトコル: USBシリアル（テキストコマンド + バイナリWAV転送）
+ポート自動検出。`--port` で手動指定も可能。
 
 ### WiFi HTTP API（`--wifi`）
 
-- IP: 環境変数 `STACKCHAN_IP` またはデフォルト `192.168.1.9`。`--host` で指定も可能
-- プロトコル: HTTP (port 80)
-- USBケーブル不要。別のPCからでも操作可能
+IP: 環境変数 `STACKCHAN_IP` で指定（`--host` でも可）。
 
-### 共通要件
+## TTS（音声合成）
 
-TTSエンジンが必要（どちらか一方でOK）：
-
-#### VOICEVOX（デフォルト）
-- VOICEVOX Engine がローカルで起動していること（port 50021）
-  - Dockerで起動: `docker run --rm -p 50021:50021 voicevox/voicevox_engine:cpu-latest`
-  - macOSでは `open -a VOICEVOX` でも起動可能
-  - 確認: `curl http://localhost:50021/version`
-  - 起動していない場合、`say` コマンドはエラーメッセージを表示して終了する
-
-#### piper-plus（VOICEVOX不要、Raspberry Pi対応）
-- [piper-plus](https://github.com/ayutaz/piper-plus) のバイナリとモデルファイルが必要
-- サーバー不要、バイナリ単体で動作。ARM64（Raspberry Pi / DGX Spark）対応
-- 日本語モデル例: `ayousanz/piper-plus-tsukuyomi-chan`（HuggingFace）
-- `--tts piper --piper-bin <path> --piper-model <path>` で指定
-
-## 対応デバイス
-
-| デバイス | 音声再生 | カメラ | 備考 |
-|----------|----------|--------|------|
-| M5Stack CoreS3 | OK（大容量WAV可） | OK | PSRAM搭載、推奨 |
-| M5Stack Core（初代） | OK（80KB以下） | なし | PSRAMなし、短い発話向け |
-| M5Stack Core2 | 未テスト | なし | PSRAM搭載 |
+- **デフォルト: piper-plus**（環境変数 `STACKCHAN_TTS` で変更可能）
+- piper-plus: サーバー不要、バイナリ単体で動作。`PIPER_BIN` と `PIPER_MODEL` 環境変数で設定
+- VOICEVOX: `--tts voicevox` で切替。ローカルエンジン（port 50021）が必要
 
 ## 実行フロー
 
@@ -95,7 +33,6 @@ cd [SKILL_DIR] && uv run tools/stackchan_atama.py status
 
 # WiFi
 cd [SKILL_DIR] && uv run tools/stackchan_atama.py --wifi status
-cd [SKILL_DIR] && uv run tools/stackchan_atama.py --wifi --host 192.168.1.5 status
 ```
 
 ### Step 2: テキスト読み上げ（TTS）
@@ -104,32 +41,20 @@ cd [SKILL_DIR] && uv run tools/stackchan_atama.py --wifi --host 192.168.1.5 stat
 # 通常モード（全文を一括送信）
 cd [SKILL_DIR] && uv run tools/stackchan_atama.py say "こんにちは"
 
-# パイプラインモード（文を分割、最初のチャンクを即座に再生開始）
+# パイプラインモード（文を分割、最初のチャンクを即座に再生開始）— 長文推奨
 cd [SKILL_DIR] && uv run tools/stackchan_atama.py say "こんにちは！今日もいい天気ですね。散歩に行きましたか？" --pipeline
 
-# 話者変更
-cd [SKILL_DIR] && uv run tools/stackchan_atama.py say "おはよう" --voice 3
+# VOICEVOX で話者変更（VOICEVOX時のみ）
+cd [SKILL_DIR] && uv run tools/stackchan_atama.py --tts voicevox say "おはよう" --voice 3
 
 # WiFi経由
 cd [SKILL_DIR] && uv run tools/stackchan_atama.py --wifi say "こんにちは" --pipeline
-
-# piper-plus でオフライン音声合成（VOICEVOX 不要、Raspberry Pi 対応）
-cd [SKILL_DIR] && uv run tools/stackchan_atama.py --tts piper \
-  --piper-bin /path/to/piper \
-  --piper-model /path/to/model.onnx \
-  say "こんにちは" --pipeline
 ```
-
-- デフォルト: VOICEVOX ローカルエンジン経由
-- `--tts piper` で piper-plus に切替（サーバー不要、ARM64対応）
-- `--pipeline` で句読点区切り＋順次送信（長文推奨）
-- `--voice` で話者ID変更（デフォルト: 1 = ずんだもん、VOICEVOX時のみ）
 
 ### Step 3: 表情変更
 
 ```bash
 cd [SKILL_DIR] && uv run tools/stackchan_atama.py face happy
-cd [SKILL_DIR] && uv run tools/stackchan_atama.py --wifi face happy
 ```
 
 表情一覧:
@@ -154,9 +79,6 @@ cd [SKILL_DIR] && uv run tools/stackchan_atama.py volume 200
 cd [SKILL_DIR] && uv run tools/stackchan_atama.py capture -o /tmp/photo.jpg
 cd [SKILL_DIR] && uv run tools/stackchan_atama.py --wifi capture -o /tmp/photo.jpg
 ```
-
-- CoreS3のGC0308カメラでJPEG撮影
-- USBシリアル・WiFiどちらでも利用可能
 
 ### Step 6: WAVファイル直接再生
 
@@ -204,34 +126,9 @@ uv run tools/stackchan_atama.py --wifi capture -o /tmp/photo.jpg
 
 ## 注意点
 
-- USBシリアルモード（デフォルト）はUSBケーブル接続が必要
-- WiFiモード（`--wifi`）はネットワーク接続が必要。IPアドレスは `--host` か環境変数 `STACKCHAN_IP` で指定
-- VOICEVOX Engine がローカルで動いている必要がある
-- シリアルポートが他のプロセスに掴まれていると接続できない
-- 長文は `--pipeline` オプションで分割送信すると体感速度が上がる
-- パイプライン再生はキュー（4スロット）に順次投入される
-- **M5Stack Core（初代）はPSRAMがないため、80KB超のWAVは受け付けない**
-  - シリアル: `WAV:` コマンドは100KB制限（`invalid size`）
-  - HTTP: `/play_wav` は80KB制限（HTTP 400）
-  - 長文は `--pipeline` で分割送信すれば問題なし
-
-## トラブルシューティング
-
-- **Permission denied（Linux）**: `sudo usermod -aG dialout $USER` して再ログイン
-- **ポートが見つからない**: USBケーブルがデータ転送対応か確認（充電専用ケーブルはNG）
-- **VOICEVOX接続エラー**: `docker ps` でコンテナ起動確認、または `curl http://localhost:50021/version` で疎通確認
-- **音が鳴らない**: `uv run tools/stackchan_atama.py volume 255` で最大音量に設定
-- **シリアルポートが掴まれている**: `lsof /dev/ttyACM0` で確認、`fuser -k /dev/ttyACM0` で解放
-- **シリアルでWAV転送が失敗する（`no READY response` / `no confirmation received`）**:
-  ホストPCの性能やUSBコントローラの特性により、デフォルトの転送速度（1KB/5ms）が速すぎる場合がある。
-  まずデフォルトで `say` を試し、失敗したら `--serial-chunk` と `--serial-delay` で速度を落とす：
-  ```bash
-  # デフォルト（高速ホスト向け）
-  uv run tools/stackchan_atama.py say "テスト"
-
-  # 転送が失敗する場合（Raspberry Pi等の低速ホスト向け）
-  uv run tools/stackchan_atama.py --serial-chunk 256 --serial-delay 0.02 say "テスト"
-  ```
+- 長文は `--pipeline` で分割送信すると体感速度が上がる
+- M5Stack Core（初代）はPSRAMがないため80KB超のWAVは不可 → `--pipeline` で回避
+- シリアル転送が失敗する場合: `--serial-chunk 256 --serial-delay 0.02` で速度を落とす
 
 ## 使用例
 

--- a/tools/stackchan_atama.py
+++ b/tools/stackchan_atama.py
@@ -16,7 +16,7 @@ Usage:
 
     # WiFi HTTP API
     uv run stackchan_atama.py --wifi say "こんにちは"
-    uv run stackchan_atama.py --wifi --host 192.168.1.9 face happy
+    uv run stackchan_atama.py --wifi --host $STACKCHAN_IP face happy
     uv run stackchan_atama.py --wifi capture -o photo.jpg
 """
 # /// script
@@ -46,10 +46,23 @@ DEFAULT_BAUD = 921600
 DEFAULT_VOICEVOX_URL = "http://127.0.0.1:50021"
 DEFAULT_VOICEVOX_SPEAKER = 1  # ずんだもん（あまあま）
 DEFAULT_SAMPLE_RATE = 16000  # 16kHz (M5Stackスピーカーには十分)
-DEFAULT_WIFI_HOST = os.environ.get("STACKCHAN_IP", "192.168.1.9")
-DEFAULT_TTS = "voicevox"  # "voicevox" or "piper"
-DEFAULT_PIPER_BIN = os.environ.get("PIPER_BIN", "piper")
-DEFAULT_PIPER_MODEL = os.environ.get("PIPER_MODEL", "")
+DEFAULT_WIFI_HOST = os.environ.get("STACKCHAN_IP", "192.168.1.100")
+DEFAULT_TTS = os.environ.get("STACKCHAN_TTS", "piper")  # "voicevox" or "piper"
+
+# piper-plus: auto-detect from skill directory (tools/piper, models/*.onnx)
+_SCRIPT_DIR = Path(__file__).resolve().parent  # tools/
+_SKILL_DIR = _SCRIPT_DIR.parent               # stackchan-atama/
+_LOCAL_PIPER_BIN = _SCRIPT_DIR / "piper"
+_LOCAL_PIPER_MODELS = sorted(_SKILL_DIR.glob("models/*.onnx"))
+
+DEFAULT_PIPER_BIN = os.environ.get(
+    "PIPER_BIN",
+    str(_LOCAL_PIPER_BIN) if _LOCAL_PIPER_BIN.exists() else "piper"
+)
+DEFAULT_PIPER_MODEL = os.environ.get(
+    "PIPER_MODEL",
+    str(_LOCAL_PIPER_MODELS[0]) if _LOCAL_PIPER_MODELS else ""
+)
 
 
 def detect_serial_port():


### PR DESCRIPTION
## Summary
- SKILL.mdをAI操作手順のみに整理（背景情報・トラブルシューティングはREADMEへ移動）
- デフォルトTTSをVOICEVOXからpiper-plusに変更（`STACKCHAN_TTS`環境変数で切替可能）
- IPアドレスのハードコードを廃止、`STACKCHAN_IP`環境変数で設定する方式に統一
- piperバイナリ・モデルをスキルディレクトリから相対パスで自動検出（`tools/piper`, `models/*.onnx`）

## Test plan
- [x] piper-plusでの音声合成動作確認済み（パス指定なし、自動検出で動作）
- [x] VOICEVOXへの切替（`--tts voicevox`）が引き続き動作すること
- [x] WiFiモードでの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)