### PR TITLE
Add AtomS3R + Atomic Echo Base support

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -5,7 +5,7 @@
 platform = espressif32
 framework = arduino
 lib_deps =
-    m5stack/M5Unified @ ^0.2.2
+    m5stack/M5Unified @ 0.2.7
     meganetaaan/M5Stack-Avatar @ ^0.10.0
     bblanchon/ArduinoJson @ ^7
     https://github.com/ESP32Async/ESPAsyncWebServer.git
@@ -28,3 +28,27 @@ board_build.partitions = default.csv
 [env:m5stack-core2]
 board = m5stack-core2
 board_build.partitions = default_16MB.csv
+
+[env:m5stack-atoms3r]
+platform    = espressif32@6.11.0
+board       = m5stack-atoms3
+framework   = arduino
+
+; ファイルシステム
+board_build.filesystem = spiffs
+
+; PSRAM 有効化
+board_build.arduino.memory_type = qio_opi
+board_build.flash_mode          = qio
+board_build.psram_type          = opi
+
+monitor_speed = 115200
+
+build_flags =
+	-DESP32S3
+	-DBOARD_HAS_PSRAM
+	-mfix-esp32-psram-cache-issue
+	-DARDUINO_USB_CDC_ON_BOOT=1
+	-DARDUINO_USB_MODE=1
+	-DARDUINO_M5STACK_ATOMS3R
+	-DARDUINOJSON_DEFAULT_NESTING_LIMIT=100

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -374,6 +374,24 @@ void handleSerialCommand(const String& cmd) {
     Serial.printf("{\"status\":\"ok\",\"volume\":%d}\n", M5.Speaker.getChannelVolume(m5spk_virtual_channel));
 
   } else if (cmd == "STATUS") {
+#ifdef ARDUINO_M5STACK_ATOMS3R
+#if defined(ENABLE_CAMERA)
+    Serial.printf("{\"status\":\"online\",\"board\":\"AtomS3R+Echo\",\"wifi\":%s,\"ip\":\"%s\",\"playing\":%s,\"queued\":%d,\"camera\":%s,\"psram\":%s}\n",
+      wifi_connected ? "true" : "false",
+      wifi_connected ? WiFi.localIP().toString().c_str() : "none",
+      wav_playing ? "true" : "false",
+      wavQueueCount(),
+      camera_initialized ? "true" : "false",
+      psramFound() ? "true" : "false");
+#else
+    Serial.printf("{\"status\":\"online\",\"board\":\"AtomS3R+Echo\",\"wifi\":%s,\"ip\":\"%s\",\"playing\":%s,\"queued\":%d,\"camera\":false,\"psram\":%s}\n",
+      wifi_connected ? "true" : "false",
+      wifi_connected ? WiFi.localIP().toString().c_str() : "none",
+      wav_playing ? "true" : "false",
+      wavQueueCount(),
+      psramFound() ? "true" : "false");
+#endif
+#else
 #if defined(ENABLE_CAMERA)
     Serial.printf("{\"status\":\"online\",\"wifi\":%s,\"ip\":\"%s\",\"playing\":%s,\"queued\":%d,\"camera\":%s,\"psram\":%s}\n",
       wifi_connected ? "true" : "false",
@@ -389,6 +407,7 @@ void handleSerialCommand(const String& cmd) {
       wav_playing ? "true" : "false",
       wavQueueCount(),
       psramFound() ? "true" : "false");
+#endif
 #endif
 
   } else if (cmd == "WIFI:CLEAR") {
@@ -660,7 +679,13 @@ void setupWiFi() {
 // ---- Setup ----
 void setup() {
   auto cfg = M5.config();
+#ifdef ARDUINO_M5STACK_ATOMS3R
+  // AtomS3R with Atomic Echo Base configuration
+  cfg.external_speaker.atomic_echo = true;
+#else
+  // Default configuration (CoreS3, Core2, etc.)
   cfg.external_spk = true;
+#endif
   M5.begin(cfg);
 
   // Re-init Serial after M5.begin() for USB CDC on ESP32-S3
@@ -669,7 +694,12 @@ void setup() {
 #else
   Serial.setRxBufferSize(4096);   // 4KB receive buffer (ESP32 classic)
 #endif
-  Serial.begin(921600);
+
+#ifdef ARDUINO_M5STACK_ATOMS3R
+  Serial.begin(115200);  // Optimized for AtomS3R
+#else
+  Serial.begin(921600);  // Default for CoreS3/Core2
+#endif
   delay(500);
 
   // Speaker config
@@ -679,12 +709,27 @@ void setup() {
     spk_cfg.dma_buf_count = 20;
     spk_cfg.dma_buf_len = 512;
     M5.Speaker.config(spk_cfg);
-    M5.Speaker.setVolume(255);  // Master volume max
+#ifdef ARDUINO_M5STACK_ATOMS3R
+    // Atomic Echo Base: use lower volume to prevent distortion
+    M5.Speaker.setVolume(192);
+    M5.Speaker.setChannelVolume(m5spk_virtual_channel, 192);
+#else
+    // Default: maximum volume
+    M5.Speaker.setVolume(255);
     M5.Speaker.setChannelVolume(m5spk_virtual_channel, 255);
+#endif
   }
 
   // Start avatar
+#ifdef ARDUINO_M5STACK_ATOMS3R
+  // AtomS3R: Initialize avatar for headless operation (no display)
+  avatar.setScale(0.5);
+  avatar.setPosition(-56, -96);
+  avatar.init();  // Avatar library auto-detects no display and uses appropriate size
+#else
+  // M5Stack devices: Use default initialization with display
   avatar.init();
+#endif
   avatar.setExpression(Expression::Neutral);
 
   // Audio output (self-contained WAV player, no ESP8266Audio dependency)
@@ -757,7 +802,11 @@ void setup() {
   camera_initialized = setupCamera();
 #endif
 
+#ifdef ARDUINO_M5STACK_ATOMS3R
+  Serial.println("[AtomS3R+Echo] Serial commands ready: FACE:expr WAV:size VOLUME:vol STATUS WIFI:ssid:pass CAPTURE");
+#else
   Serial.println("Serial commands ready: FACE:expr WAV:size VOLUME:vol STATUS WIFI:ssid:pass CAPTURE");
+#endif
 }
 
 // ---- Loop ----


### PR DESCRIPTION
## Summary

M5Stack AtomS3R + Atomic Echo Base 向けのビルド環境を追加。

- `platformio.ini` に `[env:m5stack-atoms3r]` を追加（ESP32-S3, PSRAM有効, USB CDC）
- `src/main.cpp` に `ARDUINO_M5STACK_ATOMS3R` 分岐を追加
  - Atomic Echo Base のスピーカー設定（`cfg.external_speaker.atomic_echo`）
  - Serial 115200bps（AtomS3R最適化）
  - 音量控えめ（192）で歪み防止
  - 小画面アバター表示対応
  - STATUS レスポンスにボード名 `AtomS3R+Echo` を追加

## Test

- AtomS3R 実機でビルド・書き込み・動作確認済み
- `status` → `{"status":"online","board":"AtomS3R+Echo","wifi":false,"psram":true}`
- `face happy` → 表情変更OK（小画面にアバター表示）
- `say --pipeline` → TTS + WAV転送OK（※スピーカーテストはAtomic Echo Base未接続のため未実施）

## Test Environment

### Hardware
- PC (Linux / Ubuntu)
- M5Stack AtomS3R（Atomic Echo Base なしで顔表示・シリアル通信を確認）

### Software
- PlatformIO (espressif32@6.11.0)
- M5Unified 0.2.7

## Acknowledgment

Thanks to @starf555 for the AtomS3R support implementation!